### PR TITLE
Fix up so this can be imported into the Experiment State Tracker

### DIFF
--- a/LogBookClient/LBG.py
+++ b/LogBookClient/LBG.py
@@ -1,0 +1,1 @@
+LogBookGrabber_qt

--- a/LogBookClient/LogBookGrabber_qt
+++ b/LogBookClient/LogBookGrabber_qt
@@ -1468,6 +1468,7 @@ class JIRAIssueDialog(QtWidgets.QDialog):
 
 class GUIGrabSubmitELog ( QtWidgets.QWidget ) :
     """GUI sets fields for ELog posting"""
+    lb_resize = QtCore.Signal()
 
     name = 'GUIGrabSubmitELog' # for logger
 
@@ -1821,6 +1822,7 @@ class GUIGrabSubmitELog ( QtWidgets.QWidget ) :
         #logger.debug('resizeEvent', self.name)
         self.frame.setGeometry(self.rect())
         #print 'resizeEvent: %s' % str(self.size())
+        self.lb_resize.emit()
 
 
     def moveEvent(self, e):

--- a/LogBookClient/__init__.py
+++ b/LogBookClient/__init__.py
@@ -14,6 +14,6 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-from client            import ElogClient
-from datatypes         import LogEntry, Logbook, Tag, Attachment
-from LogBookWebService import LogBookWebService
+from .client            import ElogClient
+from .datatypes         import LogEntry, Logbook, Tag, Attachment
+from .LogBookWebService import LogBookWebService


### PR DESCRIPTION
Three changes here:
    init.py (with underscores) was modified to use relative imports.
    A symbolic link LBG.py was added so the code in LogBookGrabber_qt could be imported.
    lb_resize signal was added so that when the GUIGrabSubmitELog class gets a resize event, it can notify the environment it is embedded in.
