### PR TITLE
pycaSignal, not Signal!

### DIFF
--- a/LogBookClient/LogBookGrabber_qt
+++ b/LogBookClient/LogBookGrabber_qt
@@ -1468,7 +1468,7 @@ class JIRAIssueDialog(QtWidgets.QDialog):
 
 class GUIGrabSubmitELog ( QtWidgets.QWidget ) :
     """GUI sets fields for ELog posting"""
-    lb_resize = QtCore.Signal()
+    lb_resize = QtCore.pycaSignal()
 
     name = 'GUIGrabSubmitELog' # for logger
 


### PR DESCRIPTION
Sigh.  The name changed at some point, but pycaSignal is always good.  Let's just use this.
